### PR TITLE
ifd-px4: 複数のリーダーを正しく扱えるように修正

### DIFF
--- a/userland/ifd-px4/ifdhandler.c
+++ b/userland/ifd-px4/ifdhandler.c
@@ -71,9 +71,14 @@ static RESPONSECODE px4_ifd_stop_polling(DWORD Lun)
 }
 
 /* Helper functions */
+/*
+ * The Lun is 0xRRRRSSSS: reader number in the high 16 bits, slot number in
+ * the low 16 bits (see PCSC/ifdhandler.h). We expose one slot per reader,
+ * so the reader number is what selects the context.
+ */
 static int get_reader_index(DWORD Lun)
 {
-	return (int)(Lun & 0xFFFF);
+	return (int)((Lun >> 16) & 0xFFFF);
 }
 
 static struct reader_context *get_reader(DWORD Lun)
@@ -943,14 +948,17 @@ RESPONSECODE IFDHGetCapabilities(DWORD Lun, DWORD Tag,
 	case TAG_IFD_SIMULTANEOUS_ACCESS:
 		if (*Length < 1)
 			return IFD_ERROR_INSUFFICIENT_BUFFER;
-		*Value = 1; /* One slot only */
+		/* Number of *readers* this driver can manage simultaneously,
+		 * not the number of slots per reader. Per-reader state lives
+		 * in readers[], so we can drive MAX_READERS of them. */
+		*Value = MAX_READERS;
 		*Length = 1;
 		break;
 
 	case TAG_IFD_SLOTS_NUMBER:
 		if (*Length < 1)
 			return IFD_ERROR_INSUFFICIENT_BUFFER;
-		*Value = 1; /* One slot */
+		*Value = 1; /* One slot per reader */
 		*Length = 1;
 		break;
 


### PR DESCRIPTION
PX4 系のデバイスを2台以上接続した環境で、2台目以降のカードリーダーが
pcscd に登録されず、そちらに挿したカードが PC/SC から一切見えない問題を
修正する。

原因は2つあり、どちらか片方だけを直しても動作しない。

1. TAG_IFD_SIMULTANEOUS_ACCESS に 1 を返していた

   このタグは PCSC/ifdhandler.h に "number of reader the driver can manage" とある通り、ドライバが同時に扱えるリーダー数でを返す。1 を返していたため pcscd が 2台目以降を拒否していた。

     RFSetReaderName() Driver ... does not support more than 1 reader(s).
                       Maybe the driver should support TAG_IFD_SIMULTANEOUS_ACCESS
     HPAddDevice() Failed adding USB device: PLEX PX-M1UR Smart Card Reader

   リーダーごとの状態は readers[] に保持しているので MAX_READERS を返す。 スロット数は TAG_IFD_SLOTS_NUMBER が別に扱っており、そちらは 1 のまま で正しい。

2. get_reader_index() が Lun の下位16ビットを読んでいた

   Lun は 0xRRRRSSSS で、上位16ビットがリーダー番号、下位16ビットが スロット番号。本ハンドラーは1リーダー1スロットなので下位は常に 0 に なり、すべてのリーダーが readers[0] に集約されていた。

   この状態では2台目の IFDHCreateChannelByName() が memset() で1台目の コンテキストを破壊し、その fd がリークする。カーネル側は排他 open なので、リークした fd が chardev を掴んだまま解放されなくなる。

実機での確認 (PLEX PX-M1UR 2台, /dev/pxm1urcard0 と card1):

  修正前: PLEX PX-M1UR を2台さしても Reader 0 のみ登録される
  修正後: Reader 0 , Reader 1 が登録される。opensc-tool --list-readers　で2台が取れる。

